### PR TITLE
Adding macOS

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,9 @@ galaxy_info:
     - name: Fedora
       versions:
         - all
+    - name: Darwin
+      versions:
+        - all
   galaxy_tags:
     - keybase
     - messaging

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,3 +27,11 @@
   when: ansible_os_family == "RedHat" and keybase_result.rc != 0
   package:
     name: "{{ keybase_package_url }}/keybase_amd64.rpm"
+
+- name: Install Keybase.app
+  when: ansible_os_family == "Darwin" and keybase_result.rc != 0
+  become: false
+  homebrew_cask:
+    name: keybase
+    state: present
+    update_homebrew: yes


### PR DESCRIPTION
Darwin is macOS. If Mac has the Homebrew package manager, then this role can install Keybase.