### PR TITLE
Bugfixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,15 @@
 ---
 package_dest: "/tmp"
+
+deb_dependencies:
+  - fuse
+  - libappindicator1
+  - libasound2
+  - libgconf-2-4
+  - libgtk-3-0
+  - libnss3
+  - libxss1
+  - libxtst6
+  - lsof
+  - psmisc
+  - procps

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,6 +10,8 @@ platforms:
     image: ubuntu:16.04
   - name: Ubuntu-18.04-instance
     image: ubuntu:18.04
+  - name: Fedora-31-instance
+    image: fedora:31
   - name: CentOS-7-instance
     image: centos:7
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
+  - name: Debian-instance
+    image: debian:buster
   - name: Ubuntu-16.04-instance
     image: ubuntu:16.04
   - name: Ubuntu-18.04-instance

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,16 @@
 
 - name: Install Keybase .rpm
   become: true
+  when:
+    - ansible_distribution == 'CentOS'
+    - ansible_distribution_major_version|int == 7
+    - keybase_result.rc != 0
+  yum:
+    name: "{{ keybase_package_url }}/keybase_amd64.rpm"
+    disable_gpg_check: true
+
+- name: Install Keybase package
+  become: true
   when: ansible_os_family == "RedHat" and keybase_result.rc != 0
   package:
     name: "{{ keybase_package_url }}/keybase_amd64.rpm"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,12 @@
     state: present
 
 - name: Check for Keybase
+  when: ansible_os_family != 'Windows'
   command: "keybase -v"
   changed_when: false
   check_mode: false
-  ignore_errors: true
   register: keybase_result
-  when: ansible_os_family != 'Windows'
+  failed_when: keybase_result.rc not in [0, 2]
 
 - name: Download Keybase .deb
   when: ansible_os_family == "Debian" and keybase_result.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,20 @@
   register: keybase_result
   failed_when: keybase_result.rc not in [0, 2]
 
+- name: Updating cache and auto-installing python-apt
+  when: ansible_os_family == "Debian" and keybase_result.rc != 0
+  apt:
+    name: python-apt
+    state: present
+    update_cache: yes
+    cache_valid_time: 86400
+
+- name: Installing dependencies
+  when: ansible_os_family == "Debian" and keybase_result.rc != 0
+  apt:
+    state: present
+    name: "{{ deb_dependencies }}"
+
 - name: Download Keybase .deb
   when: ansible_os_family == "Debian" and keybase_result.rc != 0
   get_url:


### PR DESCRIPTION
Molecule tests OK now for Centos 7, Debian Buster, Fedora 31, and Ubuntu 16,18.